### PR TITLE
Allow sensiolabs/security-checker version 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.4",
-        "sensiolabs/security-checker": "~1.3|~2.0|~3.0",
+        "sensiolabs/security-checker": "~1.3|~2.0|~3.0|~4.0",
         "guzzlehttp/guzzle": "~3.8|~4.0|~5.0|~6.0",
         "symfony/expression-language": "~2.3|~3.0",
         "swiftmailer/swiftmailer": "~5.4"


### PR DESCRIPTION
This version of `security-checker` fixed an issue with `open_basedir`. More info on sensiolabs/security-checker#56
